### PR TITLE
fix: decrease default text size of login and register buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+- Decrease default text size in the login and registration buttons
+
 ## 6.0.0
 
 - Refactor with the new component structure

--- a/packages/firebase_user_repository/pubspec.yaml
+++ b/packages/firebase_user_repository/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_user_repository
 description: "firebase_user_repository for flutter_user package"
-version: 6.0.0
+version: 6.0.1
 repository: https://github.com/Iconica-Development/flutter_user
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub

--- a/packages/flutter_user/lib/src/models/login/login_options.dart
+++ b/packages/flutter_user/lib/src/models/login/login_options.dart
@@ -137,7 +137,7 @@ Widget _createLoginButton(
                   padding: const EdgeInsets.all(8),
                   child: Text(
                     options.translations.loginButton,
-                    style: Theme.of(context).textTheme.displayLarge,
+                    style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ),
               ),
@@ -160,7 +160,7 @@ Widget _createRegisterButton(
         onPressed: !disabled ? onPressed : onDisabledPress,
         child: Text(
           options.translations.registrationButton,
-          style: Theme.of(context).textTheme.displayMedium!.copyWith(
+          style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                 decoration: TextDecoration.underline,
               ),
         ),

--- a/packages/flutter_user/pubspec.yaml
+++ b/packages/flutter_user/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_user
 description: "Flutter Userstory for onboarding, login, and registration."
-version: 6.0.0
+version: 6.0.1
 repository: https://github.com/Iconica-Development/flutter_user
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub

--- a/packages/user_repository_interface/pubspec.yaml
+++ b/packages/user_repository_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: user_repository_interface
 description: "user_repository_interface for flutter_user package"
-version: 6.0.0
+version: 6.0.1
 repository: https://github.com/Iconica-Development/flutter_user
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub


### PR DESCRIPTION
Before:
![Screenshot_20250115_104149](https://github.com/user-attachments/assets/73623432-0a6a-4e2b-ae76-eeb76725fd1e)

After:
![Screenshot_20250115_104123](https://github.com/user-attachments/assets/8dd02532-77b2-4541-a03a-ebe1786fd725)
