### PR TITLE
fix: stop the keyboard from closing immediately after opening because of a valuekey update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.1
+
+- Fixed a bug where the keyboard for the login username and password fields was closing because of a different LoginOptions.hashCode with the same LoginOptions values.
+
 ## 6.3.0
 
 - Added CustomSemantics widget that is used to wrap all the inputfields and buttons to make the component accessible for e2e testing.

--- a/packages/firebase_user_repository/pubspec.yaml
+++ b/packages/firebase_user_repository/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_user_repository
 description: "firebase_user_repository for flutter_user package"
-version: 6.3.0
+version: 6.3.1
 repository: https://github.com/Iconica-Development/flutter_user
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   user_repository_interface:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^6.3.0
+    version: ^6.3.1
   cloud_firestore: ^5.4.2
   firebase_auth: ^5.3.0
 

--- a/packages/flutter_user/lib/src/models/login/login_options.dart
+++ b/packages/flutter_user/lib/src/models/login/login_options.dart
@@ -1,12 +1,14 @@
 import "dart:async";
 
+import "package:equatable/equatable.dart";
 import "package:flutter/material.dart";
 import "package:flutter_user/src/models/login/login_spacer_options.dart";
 import "package:flutter_user/src/models/login/login_translations.dart";
 import "package:flutter_user/src/services/login_validation.dart";
 import "package:flutter_user/src/services/validation_service.dart";
 
-class LoginOptions {
+@immutable
+class LoginOptions extends Equatable {
   const LoginOptions({
     this.image,
     this.spacers = const LoginSpacerOptions(),
@@ -96,9 +98,33 @@ class LoginOptions {
 
   ValidationService get validations =>
       validationService ?? LoginValidationService(this);
+
+  @override
+  List<Object?> get props => [
+        // image is not added because it is a widget without Equatable
+        spacers,
+        translations,
+        validationService,
+        maxFormWidth,
+        initialEmail,
+        initialPassword,
+        emailTextAlign,
+        emailTextStyle,
+        passwordTextAlign,
+        passwordTextStyle,
+        showObscurePassword,
+        suffixIconSize,
+        suffixIconPadding,
+        loginBackgroundColor,
+        forgotPasswordButtonBuilder.runtimeType,
+        loginButtonBuilder.runtimeType,
+        registrationButtonBuilder.runtimeType,
+        emailInputContainerBuilder.runtimeType,
+        passwordInputContainerBuilder.runtimeType,
+      ];
 }
 
-class LoginBiometricsOptions {
+class LoginBiometricsOptions extends Equatable {
   const LoginBiometricsOptions({
     this.loginWithBiometrics = false,
     this.triggerBiometricsAutomatically = false,
@@ -128,10 +154,20 @@ class LoginBiometricsOptions {
 
   /// The callback function to be called when the biometrics login errors.
   final LoginOptionalAsyncCallback? onBiometricsError;
+
+  @override
+  List<Object?> get props => [
+        loginWithBiometrics,
+        triggerBiometricsAutomatically,
+        allowBiometricsAlternative,
+        onBiometricsSuccess,
+        onBiometricsFail,
+        onBiometricsError,
+      ];
 }
 
 /// Accessibility identifiers for the login widgets of the userstory.
-class LoginAccessibilityIdentifiers {
+class LoginAccessibilityIdentifiers extends Equatable {
   /// Default [LoginAccessibilityIdentifiers] constructor where all the
   /// identifiers are required. This is to ensure that apps automatically break
   /// when new identifiers are added.
@@ -179,6 +215,17 @@ class LoginAccessibilityIdentifiers {
 
   /// Identifier for the biometrics button.
   final String biometricsButtonIdentifier;
+
+  @override
+  List<Object?> get props => [
+        emailTextFieldIdentifier,
+        passwordTextFieldIdentifier,
+        loginButtonIdentifier,
+        forgotPasswordButtonIdentifier,
+        requestForgotPasswordButtonIdentifier,
+        registrationButtonIdentifier,
+        biometricsButtonIdentifier,
+      ];
 }
 
 Widget _createForgotPasswordButton(

--- a/packages/flutter_user/lib/src/models/login/login_spacer_options.dart
+++ b/packages/flutter_user/lib/src/models/login/login_spacer_options.dart
@@ -1,7 +1,8 @@
+import "package:equatable/equatable.dart";
 import "package:flutter/material.dart";
 
 @immutable
-class LoginSpacerOptions {
+class LoginSpacerOptions extends Equatable {
   const LoginSpacerOptions({
     this.spacerAfterSubtitle,
     this.spacerAfterImage,
@@ -36,4 +37,16 @@ class LoginSpacerOptions {
   final int formFlexValue;
 
   final int titleSpacer;
+
+  @override
+  List<Object?> get props => [
+        spacerBeforeTitle,
+        spacerAfterTitle,
+        spacerAfterSubtitle,
+        spacerAfterImage,
+        spacerAfterForm,
+        spacerAfterButton,
+        formFlexValue,
+        titleSpacer,
+      ];
 }

--- a/packages/flutter_user/lib/src/models/login/login_translations.dart
+++ b/packages/flutter_user/lib/src/models/login/login_translations.dart
@@ -1,4 +1,6 @@
-class LoginTranslations {
+import "package:equatable/equatable.dart";
+
+class LoginTranslations extends Equatable {
   const LoginTranslations({
     this.loginTitle = "log in",
     this.loginSubtitle,
@@ -25,4 +27,17 @@ class LoginTranslations {
 
   final String registrationButton;
   final String biometricsLoginMessage;
+
+  @override
+  List<Object?> get props => [
+        loginTitle,
+        loginSubtitle,
+        emailEmpty,
+        passwordEmpty,
+        emailInvalid,
+        loginButton,
+        forgotPasswordButton,
+        registrationButton,
+        biometricsLoginMessage,
+      ];
 }

--- a/packages/flutter_user/pubspec.yaml
+++ b/packages/flutter_user/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_user
 description: "Flutter Userstory for onboarding, login, and registration."
-version: 6.3.0
+version: 6.3.1
 repository: https://github.com/Iconica-Development/flutter_user
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   local_auth: ^2.3.0
+  equatable: ^2.0.0
   flutter_input_library:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
     version: ^3.7.0
@@ -21,7 +22,7 @@ dependencies:
     version: ^4.1.0
   user_repository_interface:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^6.3.0
+    version: ^6.3.1
   flutter_accessibility:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub
     version: ^0.0.3

--- a/packages/user_repository_interface/pubspec.yaml
+++ b/packages/user_repository_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: user_repository_interface
 description: "user_repository_interface for flutter_user package"
-version: 6.3.0
+version: 6.3.1
 repository: https://github.com/Iconica-Development/flutter_user
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub


### PR DESCRIPTION
The hashcode of the LoginOptions was not consistent so it would force the field to rebuild when the keyboard would open. The ValueKey was not needed at all for hot reloading so I removed it.